### PR TITLE
[IDP-510] Set a blanket AnalysisLevel to latest-All

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -9,6 +9,7 @@
     <LangVersion>10</LangVersion>
     <Nullable>enable</Nullable>
     <ImplicitUsings>disable</ImplicitUsings>
+    <AnalysisLevel>latest-All</AnalysisLevel>
     <Description>An opinionated library that provides base unit test and fixture classes based on the Microsoft.Extensions.* packages used by modern .NET applications.</Description>
   </PropertyGroup>
 


### PR DESCRIPTION
## Description of changes
We want to apply a code analysis of the latest .NET version used in the project. We can achieve this by adding an analysis level of latest-All.

## Breaking changes
None, we built the project with the AnalysisLevel and there are no new errors.

## Additional checks

Temporarily added property below for testing by building with diagnostics:
```
<ReportAnalyzer>true</ReportAnalyzer>
```
